### PR TITLE
Fix nested public directories when building multiple times

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -3,5 +3,5 @@
 set -x
 
 docker build -t tsub/blog:hugo -f Dockerfile-hugo .
-docker cp $(docker run -d tsub/blog:hugo):/app/public public
+docker cp $(docker run -d tsub/blog:hugo):/app/public .
 docker build -t tsub/blog .


### PR DESCRIPTION
`$ docker cp`した時同一のディレクトリがすでに存在する場合、ネストしてコピーされる